### PR TITLE
Fix for False Positive: nested attributes separated by newlines

### DIFF
--- a/lib/puppet-lint/plugins/check_trailing_comma.rb
+++ b/lib/puppet-lint/plugins/check_trailing_comma.rb
@@ -4,10 +4,14 @@ PuppetLint.new_check(:trailing_comma) do
       arrays = []
       tokens.each_with_index do |token, token_idx|
         if token.type == :LBRACK
+          level = 0
           real_idx = 0
           tokens[token_idx+1..-1].each_with_index do |cur_token, cur_token_idx|
             real_idx = token_idx + 1 + cur_token_idx
-            break if cur_token.type == :RBRACK
+
+            level += 1 if cur_token.type == :LBRACK
+            level -= 1 if cur_token.type == :RBRACK
+            break if level < 0
           end
 
           # Ignore resource references

--- a/spec/puppet-lint/plugins/check_trailing_comma/check_trailing_comma_spec.rb
+++ b/spec/puppet-lint/plugins/check_trailing_comma/check_trailing_comma_spec.rb
@@ -66,6 +66,19 @@ describe 'trailing_comma' do
         if $var =~ Sensitive {
           $foo = $var.unwrap
         }
+
+        package { 'foo':
+          require => [
+            File[
+              '/etc/foo.conf',
+              '/etc/bar.conf'
+            ],
+            Packages[
+              'bar',
+              'baz'
+            ],
+          ],
+        }
         EOS
       }
 
@@ -125,11 +138,24 @@ describe 'trailing_comma' do
             '/etc/baz.conf', '/etc/baz.conf.d'
              ],
         }
+
+        package { 'foo':
+          require => [
+            File[
+              '/etc/foo.conf',
+              '/etc/bar.conf'
+            ],
+            Packages[
+              'bar',
+              'baz'
+            ]
+          ],
+        }
         EOS
       }
 
-      it 'should detect 6 problems' do
-        expect(problems).to have(6).problems
+      it 'should detect 7 problems' do
+        expect(problems).to have(7).problems
       end
 
       it 'should create warnings' do
@@ -139,6 +165,7 @@ describe 'trailing_comma' do
         expect(problems).to contain_warning(msg).on_line(33).in_column(23)
         expect(problems).to contain_warning(msg).on_line(39).in_column(26)
         expect(problems).to contain_warning(msg).on_line(41).in_column(25)
+        expect(problems).to contain_warning(msg).on_line(59).in_column(14)
       end
     end
   end
@@ -203,6 +230,19 @@ describe 'trailing_comma' do
             '/etc/baz.conf', '/etc/baz.conf.d'
              ],
         }
+
+        package { 'foo':
+          require => [
+            File[
+              '/etc/foo.conf',
+              '/etc/bar.conf'
+            ],
+            Packages[
+              'bar',
+              'baz'
+            ],
+          ],
+        }
         EOS
       }
 
@@ -266,11 +306,24 @@ describe 'trailing_comma' do
             '/etc/baz.conf', '/etc/baz.conf.d'
              ],
         }
+
+        package { 'foo':
+          require => [
+            File[
+              '/etc/foo.conf',
+              '/etc/bar.conf'
+            ],
+            Packages[
+              'bar',
+              'baz'
+            ]
+          ],
+        }
         EOS
       }
 
-      it 'should detect 6 problems' do
-        expect(problems).to have(6).problems
+      it 'should detect 7 problems' do
+        expect(problems).to have(7).problems
       end
 
       it 'should create a warning' do
@@ -280,6 +333,7 @@ describe 'trailing_comma' do
         expect(problems).to contain_fixed(msg).on_line(33).in_column(23)
         expect(problems).to contain_fixed(msg).on_line(39).in_column(26)
         expect(problems).to contain_fixed(msg).on_line(41).in_column(25)
+        expect(problems).to contain_fixed(msg).on_line(59).in_column(14)
       end
 
       it 'should add trailing commas' do
@@ -333,7 +387,20 @@ describe 'trailing_comma' do
             '/etc/baz.conf', '/etc/baz.conf.d'
              ],
         }
-          EOS
+
+        package { 'foo':
+          require => [
+            File[
+              '/etc/foo.conf',
+              '/etc/bar.conf'
+            ],
+            Packages[
+              'bar',
+              'baz'
+            ],
+          ],
+        }
+        EOS
         )
       end
     end


### PR DESCRIPTION
Re-use the level logic from the hash section on the array section.

This fixes issue #5 