### PR TITLE
Fix custom type misdetection

### DIFF
--- a/lib/puppet-lint/plugins/check_trailing_comma.rb
+++ b/lib/puppet-lint/plugins/check_trailing_comma.rb
@@ -57,7 +57,10 @@ PuppetLint.new_check(:trailing_comma) do
       defaults = []
       tokens.each_with_index do |token, token_idx|
         if token.type == :CLASSREF && token.next_code_token && \
-          token.next_code_token.type == :LBRACE
+          token.next_code_token.type == :LBRACE && \
+          # Ensure that we aren't matching a function return type:
+          token.prev_code_token && \
+          token.prev_code_token.type != :RSHIFT
           real_idx = 0
 
           tokens[token_idx+1..-1].each_with_index do |cur_token, cur_token_idx|

--- a/lib/puppet-lint/plugins/check_trailing_comma.rb
+++ b/lib/puppet-lint/plugins/check_trailing_comma.rb
@@ -58,9 +58,11 @@ PuppetLint.new_check(:trailing_comma) do
       tokens.each_with_index do |token, token_idx|
         if token.type == :CLASSREF && token.next_code_token && \
           token.next_code_token.type == :LBRACE && \
-          # Ensure that we aren't matching a function return type:
           token.prev_code_token && \
-          token.prev_code_token.type != :RSHIFT
+          # Ensure that we aren't matching a function return type:
+          token.prev_code_token.type != :RSHIFT && \
+          # Or a conditional matching a type:
+          token.prev_code_token.type != :MATCH
           real_idx = 0
 
           tokens[token_idx+1..-1].each_with_index do |cur_token, cur_token_idx|

--- a/spec/puppet-lint/plugins/check_trailing_comma/check_trailing_comma_spec.rb
+++ b/spec/puppet-lint/plugins/check_trailing_comma/check_trailing_comma_spec.rb
@@ -55,6 +55,13 @@ describe 'trailing_comma' do
             '/etc/baz.conf', '/etc/baz.conf.d'
              ],
         }
+
+        function myfunc (
+          Mymod::Mytype $arg1,
+          String[1] $arg2,
+        ) >> Mymod::Mytype {
+          notice('foo')
+        }
         EOS
       }
 

--- a/spec/puppet-lint/plugins/check_trailing_comma/check_trailing_comma_spec.rb
+++ b/spec/puppet-lint/plugins/check_trailing_comma/check_trailing_comma_spec.rb
@@ -62,6 +62,10 @@ describe 'trailing_comma' do
         ) >> Mymod::Mytype {
           notice('foo')
         }
+
+        if $var =~ Sensitive {
+          $foo = $var.unwrap
+        }
         EOS
       }
 


### PR DESCRIPTION
Fix issue reported in #4 as well as false positives for function definitions that specify a custom return type.

Fixes #4 