### PR TITLE
Fix for type matching misdetection with !~

### DIFF
--- a/lib/puppet-lint/plugins/check_trailing_comma.rb
+++ b/lib/puppet-lint/plugins/check_trailing_comma.rb
@@ -62,7 +62,7 @@ PuppetLint.new_check(:trailing_comma) do
           # Ensure that we aren't matching a function return type:
           token.prev_code_token.type != :RSHIFT && \
           # Or a conditional matching a type:
-          token.prev_code_token.type != :MATCH
+          ! [:MATCH, :NOMATCH].include?(token.prev_code_token.type)
           real_idx = 0
 
           tokens[token_idx+1..-1].each_with_index do |cur_token, cur_token_idx|

--- a/spec/puppet-lint/plugins/check_trailing_comma/check_trailing_comma_spec.rb
+++ b/spec/puppet-lint/plugins/check_trailing_comma/check_trailing_comma_spec.rb
@@ -66,6 +66,10 @@ describe 'trailing_comma' do
         if $var =~ Sensitive {
           $foo = $var.unwrap
         }
+
+        if $var !~ Mymodule::MyType {
+          fail("encountered error ${err}")
+        }
         EOS
       }
 


### PR DESCRIPTION
The fix in 0753217f88866c4c8927b0d29d49099a54abc756 was incomplete
as it only handled the case where a positive match was used (=~).