### PR TITLE
(GH-16) Ignore data type arrays

### DIFF
--- a/lib/puppet-lint/plugins/check_trailing_comma.rb
+++ b/lib/puppet-lint/plugins/check_trailing_comma.rb
@@ -13,6 +13,11 @@ PuppetLint.new_check(:trailing_comma) do
           # Ignore resource references
           next if token.prev_code_token && \
             token.prev_code_token.type == :CLASSREF
+
+          # Ignore data types
+          next if token.prev_code_token && \
+            token.prev_code_token.type == :TYPE
+
           arrays << {
             :start  => token_idx,
             :end    => real_idx,

--- a/spec/puppet-lint/plugins/check_trailing_comma/check_trailing_comma_spec.rb
+++ b/spec/puppet-lint/plugins/check_trailing_comma/check_trailing_comma_spec.rb
@@ -10,6 +10,11 @@ describe 'trailing_comma' do
         class { '::apache':
           timeout => '100',
           docroot => '/var/www',
+          Enum[
+            'a',
+            'b',
+            'c'
+          ] $test = 'c',
         }
 
         class{ '::nginx': }
@@ -70,6 +75,12 @@ describe 'trailing_comma' do
         if $var !~ Mymodule::MyType {
           fail("encountered error ${err}")
         }
+
+        $test = [
+          'a',
+          'b',
+          'c',
+        ],
         EOS
       }
 
@@ -83,7 +94,12 @@ describe 'trailing_comma' do
         <<-EOS
         class { '::apache':
           timeout => '100',
-          docroot => '/var/www'
+          docroot => '/var/www',
+          Enum[
+            'a',
+            'b',
+            'c'
+          ] $test = 'c'
         }
 
         class{ '::nginx': }
@@ -129,20 +145,27 @@ describe 'trailing_comma' do
             '/etc/baz.conf', '/etc/baz.conf.d'
              ],
         }
+
+        $test = [
+          'a',
+          'b',
+          'c'
+        ]
         EOS
       }
 
-      it 'should detect 6 problems' do
-        expect(problems).to have(6).problems
+      it 'should detect 7 problems' do
+        expect(problems).to have(7).problems
       end
 
       it 'should create warnings' do
-        expect(problems).to contain_warning(msg).on_line(3).in_column(32)
-        expect(problems).to contain_warning(msg).on_line(10).in_column(27)
-        expect(problems).to contain_warning(msg).on_line(24).in_column(18)
-        expect(problems).to contain_warning(msg).on_line(33).in_column(23)
-        expect(problems).to contain_warning(msg).on_line(39).in_column(26)
-        expect(problems).to contain_warning(msg).on_line(41).in_column(25)
+        expect(problems).to contain_warning(msg).on_line(8).in_column(24)
+        expect(problems).to contain_warning(msg).on_line(15).in_column(27)
+        expect(problems).to contain_warning(msg).on_line(29).in_column(18)
+        expect(problems).to contain_warning(msg).on_line(38).in_column(23)
+        expect(problems).to contain_warning(msg).on_line(44).in_column(26)
+        expect(problems).to contain_warning(msg).on_line(46).in_column(25)
+        expect(problems).to contain_warning(msg).on_line(58).in_column(14)
       end
     end
 
@@ -223,6 +246,11 @@ describe 'trailing_comma' do
         class { '::apache':
           timeout => '100',
           docroot => '/var/www',
+          Enum[
+            'a',
+            'b',
+            'c'
+          ] $test = 'c',
         }
 
         class{ '::nginx': }
@@ -268,6 +296,12 @@ describe 'trailing_comma' do
             '/etc/baz.conf', '/etc/baz.conf.d'
              ],
         }
+
+        $test = [
+          'a',
+          'b',
+          'c',
+        ],
         EOS
       }
 
@@ -285,7 +319,12 @@ describe 'trailing_comma' do
         <<-EOS
         class { '::apache':
           timeout => '100',
-          docroot => '/var/www'
+          docroot => '/var/www',
+          Enum[
+            'a',
+            'b',
+            'c'
+          ] $test = 'c'
         }
 
         class{ '::nginx': }
@@ -331,20 +370,27 @@ describe 'trailing_comma' do
             '/etc/baz.conf', '/etc/baz.conf.d'
              ],
         }
+
+        $test = [
+          'a',
+          'b',
+          'c'
+        ]
         EOS
       }
 
-      it 'should detect 6 problems' do
-        expect(problems).to have(6).problems
+      it 'should detect 7 problems' do
+        expect(problems).to have(7).problems
       end
 
       it 'should create a warning' do
-        expect(problems).to contain_fixed(msg).on_line(3).in_column(32)
-        expect(problems).to contain_fixed(msg).on_line(10).in_column(27)
-        expect(problems).to contain_fixed(msg).on_line(24).in_column(18)
-        expect(problems).to contain_fixed(msg).on_line(33).in_column(23)
-        expect(problems).to contain_fixed(msg).on_line(39).in_column(26)
-        expect(problems).to contain_fixed(msg).on_line(41).in_column(25)
+        expect(problems).to contain_fixed(msg).on_line(8).in_column(24)
+        expect(problems).to contain_fixed(msg).on_line(15).in_column(27)
+        expect(problems).to contain_fixed(msg).on_line(29).in_column(18)
+        expect(problems).to contain_fixed(msg).on_line(38).in_column(23)
+        expect(problems).to contain_fixed(msg).on_line(44).in_column(26)
+        expect(problems).to contain_fixed(msg).on_line(46).in_column(25)
+        expect(problems).to contain_fixed(msg).on_line(58).in_column(14)
       end
 
       it 'should add trailing commas' do
@@ -353,6 +399,11 @@ describe 'trailing_comma' do
         class { '::apache':
           timeout => '100',
           docroot => '/var/www',
+          Enum[
+            'a',
+            'b',
+            'c'
+          ] $test = 'c',
         }
 
         class{ '::nginx': }
@@ -398,7 +449,13 @@ describe 'trailing_comma' do
             '/etc/baz.conf', '/etc/baz.conf.d'
              ],
         }
-          EOS
+
+        $test = [
+          'a',
+          'b',
+          'c',
+        ]
+        EOS
         )
       end
     end


### PR DESCRIPTION
Prior to this PR the plugin would evaluate a data types value array as a standard array type. This would cause the line to be flagged as invalid.

When running with `--fix`, the plugin would attempt to fix this condition by appending a comma token to the final element of the array.i

According to puppet-syntax this is invalid.

For example:

Vaid:

```
  Enum[
    'enforcing',
    'permissive',
    'disabled'
  ] $selinux_setting = 'permissive',

```

Invalid:

```
  Enum[
    'enforcing',
    'permissive',
    'disabled',
  ] $selinux_setting = 'permissive',

```

Running `bundle exec rake syntax` post fix returns the following
error:

```
Could not parse for environment *root*: Syntax error at ']' (file: ./test.pp, line: 7, column: 1)
```

The above is not true for normal array declarations. Puppet syntax will
happily parse a normal array with a trailing comma.

Valid auto-fix from the plugin

```
 $test = [
    'one',
    'two',
    'three',
  ]
```

This PR fixes the above by adding functionality to check whether the current `array_index` is actually an array of data type values.

If the condition is true we skip the current iteration so that it will not be linted.